### PR TITLE
fix: encriptar passwords en seeders

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "pg": "^8.11.3",
     "pg-hstore": "^2.3.4",
     "sequelize": "^6.37.0",
-    "sequelize-bcrypt": "^1.2.0",
     "sequelize-cli": "^6.6.2"
   },
   "devDependencies": {

--- a/src/controllers/authenticationController.js
+++ b/src/controllers/authenticationController.js
@@ -1,4 +1,5 @@
 import jwt from "jsonwebtoken";
+import bcrypt from "bcrypt";
 import models from "../models/index.js";
 const { User, InvalidToken } = models;
 import dotenv from 'dotenv';
@@ -13,7 +14,8 @@ async function login(req, res) {
     if (!user) {
       return res.status(401).json({ message: 'Authentication failed' });
     };
-    if (user.authenticate(req.body.password)) {
+    const login = bcrypt.compareSync(req.body.password, user.password);
+    if (login) {
       const token = jwt.sign(
         { sub: user.id },
         process.env.JWT_SECRET,

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,5 +1,4 @@
 import { Sequelize } from 'sequelize'
-import useBcrypt from 'sequelize-bcrypt';
 import dotenv from 'dotenv';
 dotenv.config();
 
@@ -38,19 +37,14 @@ const models = {
   InvalidToken: invalidTokenModel(database)
 };
 
-// Encriptar contraseñas
-useBcrypt(models.User);
-
 // Crear asociaciones
 import associations from './associations.js';
 associations(models);
 
-// Sincronizar todos los modelos
-// { force = true } borra la base de datos y luego la vuelve a sincronizar.
-// Útil para desarrollo, remover en producción
-await database.sync({ force: true })
+// Sincronizar base de datos
+await database.sync()
     .then(() => {
-    console.log("Drop and re-sync db.")
+    console.log("Database synchronized successfully");
     })
     .catch((err) => {
     console.log("Failed to sync db: " + err);

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,4 +1,5 @@
 import { DataTypes } from "sequelize";
+import bcrypt from 'bcrypt';
 
 export default (database) => {
     const User = database.define('User',{
@@ -21,6 +22,16 @@ export default (database) => {
             type:DataTypes.STRING,
             allowNull: false
         }
-    }, {tableName:'users'});
+    }, {
+        tableName:'users',
+        hooks: {
+            beforeCreate: async(user) => {
+                user.password = bcrypt.hashSync(user.password, 12)
+            },
+            beforeUpdate: async(user) => {
+                user.password = bcrypt.hashSync(user.password, 12)
+            }
+        }
+    });
     return User;
 };

--- a/src/seeders/1-role.js
+++ b/src/seeders/1-role.js
@@ -9,6 +9,6 @@ module.exports = {
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.bulkDelete('roles', null, { truncate: true, cascade: true });
+    await queryInterface.bulkDelete('roles', null, { truncate: true, cascade: true, restartIdentity: true });
   }
 };

--- a/src/seeders/2-pillar.js
+++ b/src/seeders/2-pillar.js
@@ -12,6 +12,6 @@ module.exports = {
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.bulkDelete('pillars', null, { truncate: true, cascade: true });
+    await queryInterface.bulkDelete('pillars', null, { truncate: true, cascade: true, restartIdentity: true });
   }
 };

--- a/src/seeders/3-company_type.js
+++ b/src/seeders/3-company_type.js
@@ -11,6 +11,6 @@ module.exports = {
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.bulkDelete('company_types', null, { truncate: true, cascade: true });
+    await queryInterface.bulkDelete('company_types', null, { truncate: true, cascade: true, restartIdentity: true });
   }
 };

--- a/src/seeders/4-users.js
+++ b/src/seeders/4-users.js
@@ -1,32 +1,33 @@
 'use strict';
+const bcrypt = require('bcrypt');
 
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.bulkInsert('users', [
-      { first_name: "Elena", last_name: "Martínez", email: "elena@example.com", password: "password1", phone: "123456789", createdAt: new Date(2024, 1, 7), updatedAt: new Date(2024, 1, 7), role_id: 1 },
-      { first_name: "Juan", last_name: "García", email: "juan@example.com", password: "password2", phone: "987654321", createdAt: new Date(2024, 1, 8), updatedAt: new Date(2024, 1, 8), role_id: 1 },
-      { first_name: "Sofía", last_name: "López", email: "sofia@example.com", password: "password3", phone: "555555555", createdAt: new Date(2024, 1, 9), updatedAt: new Date(2024, 1, 9), role_id: 2 },
-      { first_name: "Alejandro", last_name: "Rodríguez", email: "alejandro@example.com", password: "password4", phone: "777777777", createdAt: new Date(2024, 1, 10), updatedAt: new Date(2024, 1, 10), role_id: 1 },
-      { first_name: "Valentina", last_name: "Fernández", email: "valentina@example.com", password: "password5", phone: "333333333", createdAt: new Date(2024, 1, 11), updatedAt: new Date(2024, 1, 11), role_id: 1 },
-      { first_name: "Diego", last_name: "González", email: "diego@example.com", password: "password6", phone: "111111111", createdAt: new Date(2024, 1, 12), updatedAt: new Date(2024, 1, 12), role_id: 3 },
-      { first_name: "Lucía", last_name: "Pérez", email: "lucia@example.com", password: "password7", phone: "222222222", createdAt: new Date(2024, 1, 13), updatedAt: new Date(2024, 1, 13), role_id: 1 },
-      { first_name: "Mateo", last_name: "Sánchez", email: "mateo@example.com", password: "password8", phone: "666666666", createdAt: new Date(2024, 1, 14), updatedAt: new Date(2024, 1, 14), role_id: 1 },
-      { first_name: "Camila", last_name: "Ramírez", email: "camila@example.com", password: "password9", phone: "444444444", createdAt: new Date(2024, 1, 15), updatedAt: new Date(2024, 1, 15), role_id: 3 },
-      { first_name: "Daniel", last_name: "Torres", email: "daniel@example.com", password: "password10", phone: "999999999", createdAt: new Date(2024, 1, 16), updatedAt: new Date(2024, 1, 16), role_id: 1 },
-      { first_name: "Isabella", last_name: "Díaz", email: "isabella@example.com", password: "password11", phone: "888888888", createdAt: new Date(2024, 1, 17), updatedAt: new Date(2024, 1, 17), role_id: 3 },
-      { first_name: "Lucas", last_name: "Suárez", email: "lucas@example.com", password: "password12", phone: "777777777", createdAt: new Date(2024, 1, 18), updatedAt: new Date(2024, 1, 18), role_id: 1 },
-      { first_name: "Valeria", last_name: "Jiménez", email: "valeria@example.com", password: "password13", phone: "555555555", createdAt: new Date(2024, 1, 19), updatedAt: new Date(2024, 1, 19), role_id: 1 },
-      { first_name: "Nicolás", last_name: "López", email: "nicolas@example.com", password: "password14", phone: "333333333", createdAt: new Date(2024, 1, 20), updatedAt: new Date(2024, 1, 20), role_id: 3 },
-      { first_name: "Emma", last_name: "Perez", email: "emma@example.com", password: "password15", phone: "111111111", createdAt: new Date(2024, 1, 21), updatedAt: new Date(2024, 1, 21), role_id: 3 },
-      { first_name: "Adrián", last_name: "Hernández", email: "adrian@example.com", password: "password16", phone: "666666666", createdAt: new Date(2024, 1, 22), updatedAt: new Date(2024, 1, 22), role_id: 1 },
-      { first_name: "María", last_name: "Gómez", email: "maria@example.com", password: "password17", phone: "222222222", createdAt: new Date(2024, 1, 23), updatedAt: new Date(2024, 1, 23), role_id: 1 },
-      { first_name: "Martín", last_name: "Martínez", email: "martin@example.com", password: "password18", phone: "888888888", createdAt: new Date(2024, 1, 24), updatedAt: new Date(2024, 1, 24), role_id: 3 },
-      { first_name: "Julieta", last_name: "Flores", email: "julieta@example.com", password: "password19", phone: "999999999", createdAt: new Date(2024, 1, 25), updatedAt: new Date(2024, 1, 25), role_id: 3 },
-      { first_name: "Gabriel", last_name: "Díaz", email: "gabriel@example.com", password: "password20", phone: "444444444", createdAt: new Date(2024, 1, 26), updatedAt: new Date(2024, 1, 26), role_id: 1 }
+      { first_name: "Elena", last_name: "Martínez", email: "elena@example.com", password: bcrypt.hashSync("password1", 12), phone: "123456789", createdAt: new Date(2024, 1, 7), updatedAt: new Date(2024, 1, 7), role_id: 1 },
+      { first_name: "Juan", last_name: "García", email: "juan@example.com", password: bcrypt.hashSync("password2", 12), phone: "987654321", createdAt: new Date(2024, 1, 8), updatedAt: new Date(2024, 1, 8), role_id: 1 },
+      { first_name: "Sofía", last_name: "López", email: "sofia@example.com", password: bcrypt.hashSync("password3", 12), phone: "555555555", createdAt: new Date(2024, 1, 9), updatedAt: new Date(2024, 1, 9), role_id: 2 },
+      { first_name: "Alejandro", last_name: "Rodríguez", email: "alejandro@example.com", password: bcrypt.hashSync("password4", 12), phone: "777777777", createdAt: new Date(2024, 1, 10), updatedAt: new Date(2024, 1, 10), role_id: 1 },
+      { first_name: "Valentina", last_name: "Fernández", email: "valentina@example.com", password: bcrypt.hashSync("password5", 12), phone: "333333333", createdAt: new Date(2024, 1, 11), updatedAt: new Date(2024, 1, 11), role_id: 1 },
+      { first_name: "Diego", last_name: "González", email: "diego@example.com", password: bcrypt.hashSync("password6", 12), phone: "111111111", createdAt: new Date(2024, 1, 12), updatedAt: new Date(2024, 1, 12), role_id: 3 },
+      { first_name: "Lucía", last_name: "Pérez", email: "lucia@example.com", password: bcrypt.hashSync("password7", 12), phone: "222222222", createdAt: new Date(2024, 1, 13), updatedAt: new Date(2024, 1, 13), role_id: 1 },
+      { first_name: "Mateo", last_name: "Sánchez", email: "mateo@example.com", password: bcrypt.hashSync("password8", 12), phone: "666666666", createdAt: new Date(2024, 1, 14), updatedAt: new Date(2024, 1, 14), role_id: 1 },
+      { first_name: "Camila", last_name: "Ramírez", email: "camila@example.com", password: bcrypt.hashSync("password9", 12), phone: "444444444", createdAt: new Date(2024, 1, 15), updatedAt: new Date(2024, 1, 15), role_id: 3 },
+      { first_name: "Daniel", last_name: "Torres", email: "daniel@example.com", password: bcrypt.hashSync("password10", 12), phone: "999999999", createdAt: new Date(2024, 1, 16), updatedAt: new Date(2024, 1, 16), role_id: 1 },
+      { first_name: "Isabella", last_name: "Díaz", email: "isabella@example.com", password: bcrypt.hashSync("password11", 12), phone: "888888888", createdAt: new Date(2024, 1, 17), updatedAt: new Date(2024, 1, 17), role_id: 3 },
+      { first_name: "Lucas", last_name: "Suárez", email: "lucas@example.com", password: bcrypt.hashSync("password12", 12), phone: "777777777", createdAt: new Date(2024, 1, 18), updatedAt: new Date(2024, 1, 18), role_id: 1 },
+      { first_name: "Valeria", last_name: "Jiménez", email: "valeria@example.com", password: bcrypt.hashSync("password13", 12), phone: "555555555", createdAt: new Date(2024, 1, 19), updatedAt: new Date(2024, 1, 19), role_id: 1 },
+      { first_name: "Nicolás", last_name: "López", email: "nicolas@example.com", password: bcrypt.hashSync("password14", 12), phone: "333333333", createdAt: new Date(2024, 1, 20), updatedAt: new Date(2024, 1, 20), role_id: 3 },
+      { first_name: "Emma", last_name: "Perez", email: "emma@example.com", password: bcrypt.hashSync("password15", 12), phone: "111111111", createdAt: new Date(2024, 1, 21), updatedAt: new Date(2024, 1, 21), role_id: 3 },
+      { first_name: "Adrián", last_name: "Hernández", email: "adrian@example.com", password: bcrypt.hashSync("password16", 12), phone: "666666666", createdAt: new Date(2024, 1, 22), updatedAt: new Date(2024, 1, 22), role_id: 1 },
+      { first_name: "María", last_name: "Gómez", email: "maria@example.com", password: bcrypt.hashSync("password17", 12), phone: "222222222", createdAt: new Date(2024, 1, 23), updatedAt: new Date(2024, 1, 23), role_id: 1 },
+      { first_name: "Martín", last_name: "Martínez", email: "martin@example.com", password: bcrypt.hashSync("password18", 12), phone: "888888888", createdAt: new Date(2024, 1, 24), updatedAt: new Date(2024, 1, 24), role_id: 3 },
+      { first_name: "Julieta", last_name: "Flores", email: "julieta@example.com", password: bcrypt.hashSync("password19", 12), phone: "999999999", createdAt: new Date(2024, 1, 25), updatedAt: new Date(2024, 1, 25), role_id: 3 },
+      { first_name: "Gabriel", last_name: "Díaz", email: "gabriel@example.com", password: bcrypt.hashSync("password20", 12), phone: "444444444", createdAt: new Date(2024, 1, 26), updatedAt: new Date(2024, 1, 26), role_id: 1 }
     ])
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.bulkDelete('users', null, { truncate: true, cascade: true });
+    await queryInterface.bulkDelete('users', null, { truncate: true, cascade: true, restartIdentity: true });
   }
 };

--- a/src/seeders/5-question.js
+++ b/src/seeders/5-question.js
@@ -24,6 +24,6 @@ module.exports = {
    },
 
    async down(queryInterface, Sequelize) {
-      await queryInterface.bulkDelete('questions', null, { truncate: true, cascade: true });
+      await queryInterface.bulkDelete('questions', null, { truncate: true, cascade: true, restartIdentity: true });
    }
 };

--- a/src/seeders/6-pillarMessage.js
+++ b/src/seeders/6-pillarMessage.js
@@ -156,6 +156,6 @@ module.exports = {
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.bulkDelete('pillar_messages', null, { truncate: true, cascade: true });
+    await queryInterface.bulkDelete('pillar_messages', null, { truncate: true, cascade: true, restartIdentity: true });
   }
 };

--- a/src/seeders/7-option.js
+++ b/src/seeders/7-option.js
@@ -96,6 +96,6 @@ module.exports = {
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.bulkDelete('options', null, { truncate: true, cascade: true });
+    await queryInterface.bulkDelete('options', null, { truncate: true, cascade: true, restartIdentity: true });
   }
 };

--- a/src/seeders/8-company.js
+++ b/src/seeders/8-company.js
@@ -27,6 +27,6 @@ module.exports = {
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.bulkDelete('companies', null, { truncate: true, cascade: true });
+    await queryInterface.bulkDelete('companies', null, { truncate: true, cascade: true, restartIdentity: true });
   }
 };


### PR DESCRIPTION
* eliminada libreria sequelize-bcrypt, ahora se utiliza bcrypt directamente
* contraseñas de seeders encriptadas con `bcrypt.hashSync("plain_text_password", 12)`
* base de datos ya no se resetea al reiniciar la aplicacion, sequelize CLI permite hacer esto manualmente con `npx sequelize db:seed:undo:all` (o `npx sequelize db:seed:undo --seed seeder_filename.js` para una tabla en especifico)