### PR TITLE
Había dos lineas para diagnosticRoutes, eliminé una

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -18,6 +18,5 @@ export default (app) => {
     app.use('/diagnostic', diagnosticRoutes)
     app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocumentation));
     app.use('/pillar', pillarRoutes)
-    app.use('/diagnostic', diagnosticRoutes);
     app.use('/option', optionRoutes);
 };


### PR DESCRIPTION
ELiminé una linea repetida:  app.use('/diagnostic', diagnosticRoutes);