### PR TITLE
feat: password reset

### DIFF
--- a/src/routes/authenticationRoutes.js
+++ b/src/routes/authenticationRoutes.js
@@ -1,8 +1,11 @@
 import { Router } from 'express';
 const router = Router();
 import authController from '../controllers/authenticationController.js';
+import { validateRecovery } from '../middleware/tokenValidation.js';
 
 router.post('/login', authController.login);
 router.post('/logout', authController.logout);
+router.post('/recovery', authController.recovery_email);
+router.post('/reset_password', validateRecovery, authController.reset_password);
 
 export default router;

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -1,13 +1,13 @@
 import { Router } from 'express';
 const router = Router();
 import userController from '../controllers/userController.js';
-import userIdAccess from '../middleware/userIdAccess.js';
+import { validateUserId } from '../middleware/tokenValidation.js';
 
 router.get('/', userController.index);
-router.get('/:id', userIdAccess, userController.read);
+router.get('/:id', validateUserId, userController.read);
 router.post('/', userController.create);
-router.put('/:id', userIdAccess, userController.update);
-router.delete('/:id', userIdAccess, userController.destroy);
-router.put('/:id/password', userIdAccess, userController.change_password);
+router.put('/:id', validateUserId, userController.update);
+router.delete('/:id', validateUserId, userController.destroy);
+router.put('/:id/password', validateUserId, userController.change_password);
 
 export default router;


### PR DESCRIPTION
Reset de contraseña utilizando token temporal con bool `recovery` en payload.

Además, se cambió el nombre del middleware userCheckId.js a tokenValidation.js para mejor representar sus funciones y se modificó el formato del export para hacerlo más legible en los archivos de rutas.

!!! Token de recovery actualmente se envía como respuesta http, una vez se implemente un mailer se debe editar `recovery_email` en authenticationController.js para que se envíe al email del usuario.

** En el código el token temporal tiene una duración fija de 3 minutos. Esta bien o sería mejor definir la duración en una variable de entorno?