### PR TITLE
feat: added roles to token validation middleware

### DIFF
--- a/src/middleware/tokenValidation.js
+++ b/src/middleware/tokenValidation.js
@@ -2,25 +2,28 @@ import jwt from "jsonwebtoken";
 import models from "../models/index.js";
 const { User, InvalidToken } = models;
 
-async function validateUserId(req, res, next) {
-    try {
-        const token = req.header("authorization");
-        const decoded = jwt.verify(token, process.env.JWT_SECRET);
-        const invalidToken = await InvalidToken.findOne({
-            where: { token: token },
-            attributes: ['token']
-        });
-        const user = await User.findByPk(req.params.id, { attributes: ['password_date'] });
-        const password_date = Math.floor(user.password_date.getTime()/1000)
-        if (invalidToken || decoded.iat < password_date) {
-            return res.status(401).json({ message: 'Error 401: Unauthorized' });
-        };
-        if (req.params.id != decoded.sub) {
-            return res.status(403).json({ message: 'Error 403: Forbidden' });
-        };
-        next();
-    } catch (error) {
-        return res.status(400).json({ message: error.message });
+function validateUser (roles = [1, 2]) {
+    return async (req, res, next) => {
+        try {
+            const token = req.header("authorization");
+            const decoded = jwt.verify(token, process.env.JWT_SECRET);
+            const invalidToken = await InvalidToken.findOne({
+                where: { token: token },
+                attributes: ['token']
+            });
+            const user = await User.findByPk(decoded.sub, { attributes: ['password_date', 'role_id'] });
+            const password_date = Math.floor(user.password_date.getTime()/1000)
+            if (invalidToken || decoded.iat < password_date) {
+                return res.status(401).json({ message: 'Error 401: Unauthorized' });
+            };
+            if (req.params.id == decoded.sub || roles.includes(user.role_id)) {
+                next();
+            } else {
+                return res.status(403).json({ message: 'Error 403: Forbidden' });
+            };
+        } catch (error) {
+            return res.status(400).json({ message: error.message });
+        }
     }
 };
 
@@ -40,6 +43,6 @@ async function validateRecovery (req, res, next) {
 };
 
 export {
-    validateUserId,
+    validateUser,
     validateRecovery
 };

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -1,13 +1,13 @@
 import { Router } from 'express';
 const router = Router();
 import userController from '../controllers/userController.js';
-import { validateUserId } from '../middleware/tokenValidation.js';
+import { validateUser } from '../middleware/tokenValidation.js';
 
-router.get('/', userController.index);
-router.get('/:id', validateUserId, userController.read);
+router.get('/', validateUser([2]), userController.index);
+router.get('/:id', validateUser([2]), userController.read);
 router.post('/', userController.create);
-router.put('/:id', validateUserId, userController.update);
-router.delete('/:id', validateUserId, userController.destroy);
-router.put('/:id/password', validateUserId, userController.change_password);
+router.put('/:id', validateUser([]), userController.update);
+router.delete('/:id', validateUser([2]), userController.destroy);
+router.put('/:id/password', validateUser([]), userController.change_password);
 
 export default router;


### PR DESCRIPTION
Se agregaron roles a la validación de JWT para controlar el acceso a las rutas con la funcion `validateUser(roles)` en tokenValidation.js

Por defecto, la funcion permite que los roles 1 y 2 (user y admin) puedan acceder a la ruta, pero esto se puede modificar pasando un array con los roles permitidos a la función, por ejemplo en el caso de una ruta sólo para administradores se utiliza `validateUser([2])`. Además, la función permite bypassear este control si el ID del usuario coincide con el de la ruta, útil para la vista del perfil de usuario por ejemplo, que tanto el administrador como el usuario en cuestión deberían poder acceder. También se puede pasar un array vacio (`validateUser([])`) para ciertas funciones que sólo el usuario seleccionado puede realizar, como editar el perfil.