### PR TITLE
feat: endpoint pillar messages

### DIFF
--- a/src/controllers/pillarController.js
+++ b/src/controllers/pillarController.js
@@ -1,5 +1,5 @@
 import  models from '../models/index.js'
-const pillarModel = models.Pillar
+const { Pillar: pillarModel, PillarMessage } = models;
 
 async function create(req, res, next) {
     try {
@@ -70,11 +70,71 @@ async function destroy(req, res, next){
     }
 }
 
+async function index_messages(req, res) {
+    try {
+        console.log(pillarModel)
+        const pillar = await pillarModel.findByPk(req.params.id);
+        const messages = await pillar.getPillar_messages()
+        res.json(messages);
+    } catch (error) {
+        res.status(400).json({ message: error.message });
+    };
+};
+
+async function create_message(req, res) {
+    try {
+        if (!req.body.message || !req.body.score_limit) {
+            return res.status(400).json({ message: 'Error 400: Bad Request' });
+        }
+        const pillar = await pillarModel.findByPk(req.params.id);
+        const new_message = await pillar.createPillar_message(req.body)
+        res.json(new_message);
+    } catch (error) {
+        res.status(400).json({ message: error.message });
+    };
+};
+
+async function update_message(req, res) {
+    try {
+        if (req.body.message == '') {
+            return res.status(400).json({ message: 'Error 400: Bad Request' });
+        }
+        const message = await PillarMessage.findByPk(req.params.msg_id);
+        if (!message) { return res.status(404).json({ message: 'Error 404: Message not found' }) }
+        if (message.pillar_id == req.params.id) {
+            message.update(req.body);
+            res.status(204).end();
+        } else {
+            res.status(400).json({ message: 'Error 400: Bad Request' });
+        };
+    } catch (error) {
+        res.status(400).json({ message: error.message });
+    };
+};
+
+async function destroy_message(req, res) {
+    try {
+        const message = await PillarMessage.findByPk(req.params.msg_id);
+        if (!message) { return res.status(404).json({ message: 'Error 404: Message not found' }) }
+        if (message.pillar_id == req.params.id) {
+            message.destroy();
+            res.status(204).end();
+        } else {
+            res.status(400).json({ message: 'Error 400: Bad Request' });
+        };
+    } catch (error) {
+        res.status(400).json({ message: error.message });
+    };
+};
 
 export default {
     create,
     readAll,
     read,
     update,
-    destroy
+    destroy,
+    index_messages,
+    create_message,
+    update_message,
+    destroy_message
 }

--- a/src/routes/authenticationRoutes.js
+++ b/src/routes/authenticationRoutes.js
@@ -6,7 +6,7 @@ import { validateRecovery } from '../middleware/tokenValidation.js';
 router.post('/login', authController.login);
 router.post('/logout', authController.logout);
 router.post('/recovery', authController.recovery_email);
-router.post('/reset_password', validateRecovery, authController.reset_password);
-router.post('/activation', authController.activate_user);
+router.put('/reset_password', validateRecovery, authController.reset_password);
+router.put('/activation', authController.activate_user);
 
 export default router;

--- a/src/routes/pillarRoutes.js
+++ b/src/routes/pillarRoutes.js
@@ -4,9 +4,13 @@ const router = express.Router();
 import pillarController from '../controllers/pillarController.js';
 
 router.post("/create", pillarController.create);
-router.get("/", pillarController.readAll)
-router.get("/:id", pillarController.read)
-router.put("/:id", pillarController.update)
-router.delete("/:id", pillarController.destroy) 
+router.get("/", pillarController.readAll);
+router.get("/:id", pillarController.read);
+router.put("/:id", pillarController.update);
+router.delete("/:id", pillarController.destroy);
+router.get("/:id/messages", pillarController.index_messages);
+router.post("/:id/messages", pillarController.create_message);
+router.put("/:id/messages/:msg_id", pillarController.update_message);
+router.delete("/:id/messages/:msg_id", pillarController.destroy_message);
 
 export default router;


### PR DESCRIPTION
- GET /pillar/:id/messages: ver todos los mensajes
- POST /pillar/:id/messages: crear un mensaje para el pilar {:id}
- PUT /pillar/:id/messages/:msg_id: editar mensaje con id {:msg_id}, valida que corresponda con el id del pilar utilizando {:id}
- DELETE /pillar/:id/messages/:msg_id: eliminar mensaje con id {:msg_id}, valida que corresponda con el id del pilar utilizando {:id}

Además corregí un detalle con las rutas de reset de contraseña y activación de usuario, estaban definidas como POST cuando deberían ser PUT.