### PR TITLE
feat: db:sync script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "dev": "nodemon app.js"
+    "dev": "nodemon app.js",
+    "db:sync": "node src/build/db_sync.js"
   },
   "repository": {
     "type": "git",

--- a/src/build/db_sync.js
+++ b/src/build/db_sync.js
@@ -1,0 +1,11 @@
+import models from "../models/index.js";
+const { database } = models;
+
+await database.sync({ force: process.env.npm_config_reset })
+    .then(() => {
+    console.log("Database synchronized successfully");
+    process.exit();
+    })
+    .catch((err) => {
+    console.log("Failed to sync db: " + err);
+    });

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -2,7 +2,6 @@ import { Sequelize } from 'sequelize'
 import dotenv from 'dotenv';
 dotenv.config();
 
-// Importar modelos
 import userModel from "./user.js";
 import questionModel from './question.js';
 import pillarModel from './pillar.js';
@@ -37,18 +36,8 @@ const models = {
   InvalidToken: invalidTokenModel(database)
 };
 
-// Crear asociaciones
 import associations from './associations.js';
 associations(models);
-
-// Sincronizar base de datos
-await database.sync()
-    .then(() => {
-    console.log("Database synchronized successfully");
-    })
-    .catch((err) => {
-    console.log("Failed to sync db: " + err);
-    });
 
 models.database = database;
 export default models;


### PR DESCRIPTION
Se movió el código de sincronización de base de datos a un script aparte y se creó un comando de npm para ejecutarlo.

Uso: `npm run db:sync [--reset]`

Al pasar el argumento --reset hace un reset completo de la base de datos.